### PR TITLE
Add modal conversions and terminal style web UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,53 @@
-# m2m
-Major to minor, minor to major! does what it says on the tin.
+# M2M
+
+M2M is a small tool for converting MIDI (or transcribed audio) between musical modes. It can download audio from YouTube, transcribe piano pieces with [Transkun](https://github.com/braindefender/transkun) and shift all notes to a new mode.
+
+## Features
+
+- Convert from major (Ionian) to natural minor (Aeolian), harmonic minor or any other church mode (Dorian, Phrygian, Lydian, Mixolydian, Locrian).
+- Convert from minor back to major.
+- Works with local MIDI files or audio/YouTube links (audio is transcribed to MIDI).
+- Simple Flask web frontend with a faux "terminal" look.
+
+## Installation
+
+```bash
+pip install -r requirements.txt
+```
+
+Transkun requires additional dependencies and a working `sox` installation. Refer to its documentation if transcription fails.
+
+## Command line usage
+
+Interactive mode:
+
+```bash
+python final.py
+```
+
+You will be prompted for a source (local file or YouTube URL), an output filename and the target mode.
+
+Direct mode:
+
+```bash
+python final.py input_file output.mid
+```
+
+## Modes
+
+The following target modes are available when starting from a major key:
+
+- **Aeolian** (natural minor)
+- **Harmonic minor**
+- **Dorian**
+- **Phrygian**
+- **Lydian**
+- **Mixolydian**
+- **Locrian**
+
+Optionally you can convert from minor back to **Major**.
+
+## Web frontend
+
+Run `python web_app.py` and open `http://localhost:5000` in a browser. The page resembles a green-on-black terminal. Upload a MIDI file or provide a YouTube link, choose the target mode and download the converted MIDI.
+

--- a/index.html
+++ b/index.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>M2M Converter</title>
+<style>
+body {
+  background: #000;
+  color: #0f0;
+  font-family: monospace;
+  font-size: 24px;
+  padding: 20px;
+}
+input, select, button {
+  background: #000;
+  color: #0f0;
+  border: 1px solid #0f0;
+  font-family: monospace;
+  font-size: 24px;
+  margin: 5px 0;
+}
+</style>
+</head>
+<body>
+<h1>M2M Converter</h1>
+<form action="/convert" method="post" enctype="multipart/form-data">
+<div>Upload MIDI file: <input type="file" name="midi"></div>
+<div>or YouTube URL: <input type="text" name="url" size="40"></div>
+<div>
+ Target mode:
+ <select name="mode">
+  <option value="aeolian">Aeolian</option>
+  <option value="harmonic_minor">Harmonic Minor</option>
+  <option value="dorian">Dorian</option>
+  <option value="phrygian">Phrygian</option>
+  <option value="lydian">Lydian</option>
+  <option value="mixolydian">Mixolydian</option>
+  <option value="locrian">Locrian</option>
+  <option value="major">Major</option>
+ </select>
+</div>
+<div>Output filename: <input type="text" name="out" value="output.mid"></div>
+<button type="submit">Convert</button>
+</form>
+</body>
+</html>

--- a/web_app.py
+++ b/web_app.py
@@ -1,0 +1,48 @@
+from flask import Flask, request, send_file
+import tempfile
+import os
+import pretty_midi
+from final import (
+    download_audio_from_url,
+    audio_to_polyphonic_midi,
+    infer_tonic_name,
+    convert_to_mode,
+    ensure_mid_extension,
+)
+
+app = Flask(__name__)
+
+HTML_PAGE = open('index.html', 'r').read()
+
+@app.route('/')
+def index():
+    return HTML_PAGE
+
+@app.route('/convert', methods=['POST'])
+def convert():
+    mode = request.form.get('mode', 'aeolian')
+    outname = ensure_mid_extension(request.form.get('out', 'output.mid'))
+    url = request.form.get('url', '').strip()
+    midi_file = request.files.get('midi')
+    if midi_file and midi_file.filename:
+        tmp_mid = tempfile.NamedTemporaryFile(suffix='.mid', delete=False)
+        midi_file.save(tmp_mid.name)
+        src_mid = tmp_mid.name
+    elif url:
+        audio_path = download_audio_from_url(url)
+        tmp_mid = tempfile.NamedTemporaryFile(suffix='.mid', delete=False)
+        audio_to_polyphonic_midi(audio_path, tmp_mid.name)
+        src_mid = tmp_mid.name
+        os.remove(audio_path)
+    else:
+        return 'No input provided', 400
+
+    pm = pretty_midi.PrettyMIDI(src_mid)
+    tonic_pc = pretty_midi.note_name_to_number(infer_tonic_name(pm)) % 12
+    convert_to_mode(pm, tonic_pc, mode)
+    out_path = tempfile.NamedTemporaryFile(suffix='.mid', delete=False).name
+    pm.write(out_path)
+    return send_file(out_path, as_attachment=True, download_name=outname)
+
+if __name__ == '__main__':
+    app.run()


### PR DESCRIPTION
## Summary
- expand `final.py` to support conversions to other church modes
- add simple Flask web frontend with terminal look
- document features, modes and web usage in README

## Testing
- `python -m py_compile final.py web_app.py`

------
https://chatgpt.com/codex/tasks/task_e_6877941ea0248321869fc90fd3ec93b4