### PR TITLE
Fix convert path for Flask usage

### DIFF
--- a/web_app.py
+++ b/web_app.py
@@ -44,5 +44,12 @@ def convert():
     pm.write(out_path)
     return send_file(out_path, as_attachment=True, download_name=outname)
 
+# Netlify expects the serverless function under '/.netlify/functions/convert'.
+# When running this Flask app locally, the HTML still posts to that path, so we
+# provide an alias that reuses the same logic.
+@app.route('/.netlify/functions/convert', methods=['POST'])
+def convert_netlify():
+    return convert()
+
 if __name__ == '__main__':
     app.run()


### PR DESCRIPTION
## Summary
- add alias route in `web_app.py` so `/convert` also works via `/.netlify/functions/convert`

## Testing
- `python -m py_compile web_app.py netlify/functions/convert.py final.py`


------
https://chatgpt.com/codex/tasks/task_e_6877d1f0384c8321976aa39b1c493891